### PR TITLE
Update ads_insights_country schema

### DIFF
--- a/tap_facebook/schemas/ads_insights_country.json
+++ b/tap_facebook/schemas/ads_insights_country.json
@@ -92,6 +92,12 @@
         "number"
       ]
     },
+    "account_currency": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "account_name": {
       "type": [
         "null",


### PR DESCRIPTION
### Description of change

Add the `account_currency` field to the `ads_insights_country` schema. Reference for this field can be found here: https://developers.facebook.com/docs/marketing-api/reference/adgroup/insights/

### Manual QA steps

I ran the tap locally and can confirm that we get data containing the new field.

### Rollback steps

Revert this branch
